### PR TITLE
move react, react-dom to peerDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,9 @@ node_js:
   - "0.10"
   - "0.12"
 
+install:
+  - npm install react react-dom
+  - npm install
+
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
   ],
   "author": "Romain Berger <romain@romainberger.com>",
   "license": "MIT",
-  "dependencies": {
-    "is-client": "0.0.2",
-    "object-assign": "^4.0.1",
+  "peerDependencies": {
     "react": "^0.14.0",
     "react-dom": "^0.14.0"
+  },
+  "dependencies": {
+    "is-client": "0.0.2",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "babel": "^5.8.21",


### PR DESCRIPTION
react and react-dom being a peerDependencie prevents to duplicate react packages when bundling (with webpack or browserify), [see this article for more context](https://medium.com/@dan_abramov/two-weird-tricks-that-fix-react-7cf9bbdef375#.uag2934iw).

also, this approach is taken by other [popular project](https://github.com/rackt/react-redux/blob/master/package.json#L73)