### PR TITLE
remove deprecated function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -372,7 +372,7 @@ export default class ToolTip extends React.Component {
     this.renderPortal(newProps)
   }
   componentWillUnmount() {
-    portalNodes[this.props.group] && React.unmountComponentAtNode(portalNodes[this.props.group].el)
+    portalNodes[this.props.group] && ReactDOM.unmountComponentAtNode(portalNodes[this.props.group].el)
   }
   createPortal() {
     portalNodes[this.props.group] = {


### PR DESCRIPTION
`React.unmountComponentAtNode` is deprecated, it will cause a warning.