### PR TITLE
Fix align for bottom arrow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,9 +113,9 @@ class Card extends React.Component {
       }
       if (arrow === 'bottom') {
         fgStyle.top = null
-        fgStyle.bottom = this.margin + 1
+        fgStyle.bottom = this.margin - 7
         bgStyle.top = null
-        bgStyle.bottom = this.margin
+        bgStyle.bottom = this.margin - 8
       }
     }
     else {


### PR DESCRIPTION
Hi, @romainberger. You have a good project. Would like to contribute few bugfixes. This is the first.

Arrow was a bit off by few px, could you review it please?

Fixes problem with following cases:

- `<ToolTip position="left" arrow="bottom">`
- `<ToolTip position="right" arrow="bottom">`

A parent for test: `<div style={{outline: '1px solid red', height: 0, width: 0}}/>`

Haven't tested other cases through. And not sure I got this change right :wink: 
