### PR TITLE
Allow disabling of hover behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,13 +20,15 @@ class Card extends React.Component {
       'bottom',
       'left'
     ]),
-    style: PropTypes.object
+    style: PropTypes.object,
+    useHover: PropTypes.bool
   }
   static defaultProps = {
     active: false,
     position: 'right',
     arrow: null,
-    style: {style: {}, arrowStyle: {}}
+    style: {style: {}, arrowStyle: {}},
+    useHover: true
   }
   state = {
     hover: false,
@@ -403,7 +405,7 @@ class Card extends React.Component {
     return {style, arrowStyle}
   }
   handleMouseEnter() {
-    this.props.active && this.setState({hover: true})
+    this.props.active && this.props.useHover && this.setState({hover: true})
   }
   handleMouseLeave() {
     this.setState({hover: false})


### PR DESCRIPTION
Hey guys, thanks for the great component!

I've added the useHover prop to allow clients to turn off the default hover behavior.
This is specifically useful when you want to have a tooltip that is displayed by default, and that has a close button inside it. 
In this case, if the default hover behavior is enabled, the user has to click close, and then mouseOut of the tooltip, instead of just clicking close. This is especially problematic for mobile.

Let me know what you think, and if you'd like me to make any modifications.
