### PR TITLE
Remove `is-client` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "react-dom": "^15.1.0"
   },
   "dependencies": {
-    "is-client": "0.0.2",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, {PropTypes} from 'react'
 import ReactDOM, {unstable_renderSubtreeIntoContainer as renderSubtreeIntoContainer} from 'react-dom'
-import isClient from 'is-client'
 import assign from 'object-assign'
 
 class Card extends React.Component {
@@ -460,9 +459,7 @@ export default class ToolTip extends React.Component {
       return
     }
 
-    if (isClient()) {
-      this.renderPortal(this.props)
-    }
+    this.renderPortal(this.props)
   }
   componentWillReceiveProps(nextProps) {
     if ((!portalNodes[this.props.group] && !nextProps.active) ||


### PR DESCRIPTION
`componentDidMount` is called only client side, so there will be no problem in case of SSR if there is no extra client check here.