### PR TITLE
Sticky mode to disable close onMouseLeave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React Portal Tooltip 
+# React Portal Tooltip
 
 Awesome tooltips.
 
@@ -68,6 +68,7 @@ class MyComponent extends React.Component {
 * `parent`: the tooltip will be placed next to this element
 * `group`: string, necessary if you want several independant tooltips
 * `style`: object, allows customizing the tooltip. Checkout the [example](https://github.com/romainberger/react-portal-tooltip/blob/master/example/src/style.js) for details.
+* `sticky`: boolean, the tooltip will not be closed when you move your cursor out of the tooltip. This is useful when you want to totally control the visibility of the tooltip.
 
 ## Development
 

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -23,6 +23,7 @@ export default class App extends React.Component {
                           <li><Link to="/">Basic usage</Link></li>
                           <li><Link to="/groups">Groups</Link></li>
                           <li><Link to="/style">Style</Link></li>
+                          <li><Link to="/sticky">Sticky mode</Link></li>
                         </ul>
                     </div>
                 </div>

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -5,6 +5,7 @@ import App from './app'
 import Home from './home'
 import Groups from './groups'
 import Style from './style'
+import Sticky from './sticky'
 
 ReactDOM.render((
   <Router>
@@ -12,6 +13,7 @@ ReactDOM.render((
       <Route path="/" component={Home}/>
       <Route path="/groups" component={Groups}/>
       <Route path="/style" component={Style}/>
+      <Route path="/sticky" component={Sticky}/>
     </Route>
   </Router>
 ), document.querySelector('#root'))

--- a/example/src/sticky.js
+++ b/example/src/sticky.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import List from './list'
+import ToolTip from './../../src'
+
+export default class Groups extends React.Component {
+  state = {
+    active: false
+  }
+  escape(html) {
+    return document.createElement('div').appendChild(document.createTextNode(html)).parentNode.innerHTML
+  }
+  getExampleCode() {
+    return {
+      __html: this.escape(`<ToolTip active={this.state.active}
+         sticky
+         parent="#result"
+         tooltipTimeout={0}>
+  ToolTip content here
+</ToolTip>`)
+    }
+  }
+  onClick(e) {
+    this.setState({
+      active: !this.state.active
+    })
+  }
+  render() {
+    return (
+      <div className="row" style={{marginTop: 20}}>
+        <div className="col-lg-12">
+          <div className="row">
+            <div className="col-lg-12">
+              The <code>sticky</code> props will allow you to control the visibility of the tooltip completely. By default it is set to <code>false</code> so that the tooltip will be automatically closed when you move your cursor out of it. This is useful when you want to have a simple menu for your users to select
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-lg-12">
+              <pre dangerouslySetInnerHTML={this.getExampleCode()}/>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-lg-12">
+              <button className="btn btn-default" id="result" onClick={::this.onClick}>Sticky mode</button>
+              <ToolTip active={this.state.active}
+                       sticky
+                       parent="#result"
+                       tooltipTimeout={0}>
+                <div><input className="input" type="radio" name="meh" /> Choose me!</div>
+                <div><input className="input" type="radio" name="meh" /> No, me me</div>
+              </ToolTip>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -402,9 +402,11 @@ class Card extends React.Component {
     return {style, arrowStyle}
   }
   handleMouseEnter() {
+    if (this.props.sticky) return;
     this.props.active && this.setState({hover: true})
   }
   handleMouseLeave() {
+    if (this.props.sticky) return;
     this.setState({hover: false})
   }
   componentDidMount() {
@@ -447,12 +449,14 @@ export default class ToolTip extends React.Component {
     parent: PropTypes.string.isRequired,
     active: PropTypes.bool,
     group: PropTypes.string,
-    tooltipTimeout: PropTypes.number
+    tooltipTimeout: PropTypes.number,
+    sticky: PropTypes.bool
   }
   static defaultProps = {
     active: false,
     group: 'main',
-    tooltipTimeout: 500
+    tooltipTimeout: 500,
+    sticky: false
   }
   componentDidMount() {
     if (!this.props.active) {

--- a/src/index.js
+++ b/src/index.js
@@ -402,11 +402,11 @@ class Card extends React.Component {
     return {style, arrowStyle}
   }
   handleMouseEnter() {
-    if (this.props.sticky) return;
+    if (this.props.sticky) return
     this.props.active && this.setState({hover: true})
   }
   handleMouseLeave() {
-    if (this.props.sticky) return;
+    if (this.props.sticky) return
     this.setState({hover: false})
   }
   componentDidMount() {


### PR DESCRIPTION
In our project, we need to show some options in the tooltip for our users to select. Having the tooltip closed when losing focus (move cursor out of it for example) is not user friendly, IMO

Also, is it possible to include the built `lib` folder in git?