### PR TITLE
Add possibility to pass parent ref instead of id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -445,7 +445,10 @@ var portalNodes = {}
 
 export default class ToolTip extends React.Component {
   static propTypes = {
-    parent: PropTypes.string.isRequired,
+    parent: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ]).isRequired,
     active: PropTypes.bool,
     group: PropTypes.string,
     tooltipTimeout: PropTypes.number
@@ -504,7 +507,7 @@ export default class ToolTip extends React.Component {
       this.createPortal()
     }
     let {parent, ...other} = props
-    let parentEl = document.querySelector(parent)
+    let parentEl = typeof parent === 'string' ? document.querySelector(parent) : parent
     renderSubtreeIntoContainer(this, <Card parentEl={parentEl} {...other}/>, portalNodes[this.props.group].node)
   }
   shouldComponentUpdate() {


### PR DESCRIPTION
**Overview:**

PR contains component enhancement: possibility to pass parent ref instead of id.

@romainberger To my mind it's a nice to have feature. What do you think about that?

**How to use:**
```
<div ref={(element) => { this.element = element }} onMouseEnter={this.showTooltip} onMouseLeave={this.hideTooltip}>
  Hover me!!!
</div>
<ToolTip active={this.state.isTooltipActive} position="top" arrow="center" parent={this.element}>
  <div>
    <p>This is the content of the tooltip</p>
  </div>
</ToolTip>
```