### PR TITLE
Fix tooltip arrow positioning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ class Card extends React.Component {
       }
     }
     else {
-      fgStyle.left = (this.state.width / 2) - FG_SIZE
+      fgStyle.left = Math.round((this.state.width / 2) - FG_SIZE)
       fgStyle.borderLeft = fgTransBorder
       fgStyle.borderRight = fgTransBorder
       fgStyle.marginLeft = 0
@@ -227,11 +227,11 @@ class Card extends React.Component {
         if (parent) {          
           const tooltipWidth = this.state.width
           let bgStyleRight = arrowStyle.bgStyle.right
-          // If it's arrow center
+          // For arrow = center
           if (!bgStyleRight) {
             bgStyleRight = (tooltipWidth / 2) - BG_SIZE
           }
-          const newBgRight = bgStyleRight - style.left + this.margin
+          const newBgRight = Math.round(bgStyleRight - style.left + this.margin)
           arrowStyle = Object.assign({}, arrowStyle, {
             bgStyle: Object.assign({}, arrowStyle.bgStyle, {right: newBgRight, left: null}),
             fgStyle: Object.assign({}, arrowStyle.fgStyle, {right: newBgRight + 1, left: null})

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import ReactDOM, {unstable_renderSubtreeIntoContainer as renderSubtreeIntoContainer} from 'react-dom'
 import assign from 'object-assign'
 
-let FG_SIZE = 8
-let BG_SIZE = 9
+const FG_SIZE = 8
+const BG_SIZE = 9
 
 class Card extends React.Component {
   static propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -226,10 +226,17 @@ class Card extends React.Component {
   checkWindowPosition(style, arrowStyle) {
     if (this.props.position === 'top' || this.props.position === 'bottom') {
       if (style.left < 0) {
-        let offset = style.left
+        const parent = this.props.parentEl
+        if (parent && this.tooltipref) {          
+          const tooltipWidth = this.tooltipref.offsetWidth
+          const parentWidth = parent.offsetWidth
+          const newBgRight = Math.round(arrowStyle.bgStyle.right - style.left + this.margin)
+          arrowStyle = Object.assign({}, arrowStyle, {
+            bgStyle: Object.assign({}, arrowStyle.bgStyle, {right: newBgRight}),
+            fgStyle: Object.assign({}, arrowStyle.fgStyle, {right: newBgRight + 1})
+          })
+        }
         style.left = this.margin
-        arrowStyle.fgStyle.marginLeft += offset
-        arrowStyle.bgStyle.marginLeft += offset
       }
       else {
         let rightOffset = style.left + this.state.width - window.innerWidth
@@ -241,7 +248,6 @@ class Card extends React.Component {
         }
       }
     }
-
     return {style, arrowStyle}
   }
   handleMouseEnter() {
@@ -269,7 +275,7 @@ class Card extends React.Component {
     let {style, arrowStyle} = this.checkWindowPosition(this.getGlobalStyle(), this.getArrowStyle())
 
     return (
-      <div style={style} onMouseEnter={::this.handleMouseEnter} onMouseLeave={::this.handleMouseLeave}>
+      <div ref={(node) => this.tooltipref = node} style={style} onMouseEnter={::this.handleMouseEnter} onMouseLeave={::this.handleMouseLeave}>
         {this.props.arrow ? (
           <div>
             <span style={arrowStyle.fgStyle}/>

--- a/src/index.js
+++ b/src/index.js
@@ -228,14 +228,14 @@ class Card extends React.Component {
     if (this.props.position === 'top' || this.props.position === 'bottom') {
       if (style.left < 0) {
         const parent = this.props.parentEl
-        if (parent && this.tooltipref) {          
-          const tooltipWidth = this.tooltipref.offsetWidth
+        if (parent) {          
+          const tooltipWidth = this.state.width
           let bgStyleRight = arrowStyle.bgStyle.right
           // If it's arrow center
           if (!bgStyleRight) {
-            bgStyleRight = (tooltipWidth / 2) - (BG_SIZE / 2)
+            bgStyleRight = (tooltipWidth / 2) - BG_SIZE
           }
-          const newBgRight = Math.round(bgStyleRight - style.left + this.margin)
+          const newBgRight = bgStyleRight - style.left + this.margin
           arrowStyle = Object.assign({}, arrowStyle, {
             bgStyle: Object.assign({}, arrowStyle.bgStyle, {right: newBgRight, left: null}),
             fgStyle: Object.assign({}, arrowStyle.fgStyle, {right: newBgRight + 1, left: null})
@@ -280,7 +280,7 @@ class Card extends React.Component {
     let {style, arrowStyle} = this.checkWindowPosition(this.getGlobalStyle(), this.getArrowStyle())
 
     return (
-      <div ref={(node) => this.tooltipref = node} style={style} onMouseEnter={::this.handleMouseEnter} onMouseLeave={::this.handleMouseLeave}>
+      <div style={style} onMouseEnter={::this.handleMouseEnter} onMouseLeave={::this.handleMouseLeave}>
         {this.props.arrow ? (
           <div>
             <span style={arrowStyle.fgStyle}/>

--- a/src/index.js
+++ b/src/index.js
@@ -232,9 +232,9 @@ class Card extends React.Component {
             bgStyleRight = (tooltipWidth / 2) - BG_SIZE
           }
           const newBgRight = Math.round(bgStyleRight - style.left + this.margin)
-          arrowStyle = Object.assign({}, arrowStyle, {
-            bgStyle: Object.assign({}, arrowStyle.bgStyle, {right: newBgRight, left: null}),
-            fgStyle: Object.assign({}, arrowStyle.fgStyle, {right: newBgRight + 1, left: null})
+          arrowStyle = assign({}, arrowStyle, {
+            bgStyle: assign({}, arrowStyle.bgStyle, {right: newBgRight, left: null}),
+            fgStyle: assign({}, arrowStyle.fgStyle, {right: newBgRight + 1, left: null})
           })
         }
         style.left = this.margin

--- a/src/index.js
+++ b/src/index.js
@@ -122,14 +122,14 @@ class Card extends React.Component {
       }
     }
     else {
-      fgStyle.left = '50%'
-      fgStyle.marginLeft = -10
+      fgStyle.left = (this.state.width / 2) - FG_SIZE
       fgStyle.borderLeft = fgTransBorder
       fgStyle.borderRight = fgTransBorder
-      bgStyle.left = '50%'
-      bgStyle.marginLeft = -11
+      fgStyle.marginLeft = 0
+      bgStyle.left = fgStyle.left - 1
       bgStyle.borderLeft = bgTransBorder
       bgStyle.borderRight = bgTransBorder
+      bgStyle.marginLeft = 0
 
       if (position === 'top') {
         fgStyle.bottom = -10
@@ -147,16 +147,12 @@ class Card extends React.Component {
       if (arrow === 'right') {
         fgStyle.left = null
         fgStyle.right = this.margin + 1 - FG_SIZE
-        fgStyle.marginLeft = 0
         bgStyle.left = null
         bgStyle.right = this.margin - FG_SIZE
-        bgStyle.marginLeft = 0
       }
       if (arrow === 'left') {
         fgStyle.left = this.margin + 1 - FG_SIZE
-        fgStyle.marginLeft = 0
         bgStyle.left = this.margin - FG_SIZE
-        bgStyle.marginLeft = 0
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types'
 import ReactDOM, {unstable_renderSubtreeIntoContainer as renderSubtreeIntoContainer} from 'react-dom'
 import assign from 'object-assign'
 
+let FG_SIZE = 8
+let BG_SIZE = 9
+
 class Card extends React.Component {
   static propTypes = {
     active: PropTypes.bool,
@@ -76,12 +79,10 @@ class Card extends React.Component {
     let arrowStyle = assign(this.defaultArrowStyle, this.props.style.arrowStyle)
     let bgBorderColor = arrowStyle.borderColor ? arrowStyle.borderColor : 'transparent'
 
-    let fgSize = 8
-    let bgSize = 9
     let fgColorBorder = `10px solid ${arrowStyle.color}`
-    let fgTransBorder = `${fgSize}px solid transparent`
+    let fgTransBorder = `${FG_SIZE}px solid transparent`
     let bgColorBorder = `11px solid ${bgBorderColor}`
-    let bgTransBorder = `${bgSize}px solid transparent`
+    let bgTransBorder = `${BG_SIZE}px solid transparent`
 
     let {position, arrow} = this.props
 
@@ -145,16 +146,16 @@ class Card extends React.Component {
 
       if (arrow === 'right') {
         fgStyle.left = null
-        fgStyle.right = this.margin + 1 - fgSize
+        fgStyle.right = this.margin + 1 - FG_SIZE
         fgStyle.marginLeft = 0
         bgStyle.left = null
-        bgStyle.right = this.margin - fgSize
+        bgStyle.right = this.margin - FG_SIZE
         bgStyle.marginLeft = 0
       }
       if (arrow === 'left') {
-        fgStyle.left = this.margin + 1 - fgSize
+        fgStyle.left = this.margin + 1 - FG_SIZE
         fgStyle.marginLeft = 0
-        bgStyle.left = this.margin - fgSize
+        bgStyle.left = this.margin - FG_SIZE
         bgStyle.marginLeft = 0
       }
     }
@@ -229,11 +230,15 @@ class Card extends React.Component {
         const parent = this.props.parentEl
         if (parent && this.tooltipref) {          
           const tooltipWidth = this.tooltipref.offsetWidth
-          const parentWidth = parent.offsetWidth
-          const newBgRight = Math.round(arrowStyle.bgStyle.right - style.left + this.margin)
+          let bgStyleRight = arrowStyle.bgStyle.right
+          // If it's arrow center
+          if (!bgStyleRight) {
+            bgStyleRight = (tooltipWidth / 2) - (BG_SIZE / 2)
+          }
+          const newBgRight = Math.round(bgStyleRight - style.left + this.margin)
           arrowStyle = Object.assign({}, arrowStyle, {
-            bgStyle: Object.assign({}, arrowStyle.bgStyle, {right: newBgRight}),
-            fgStyle: Object.assign({}, arrowStyle.fgStyle, {right: newBgRight + 1})
+            bgStyle: Object.assign({}, arrowStyle.bgStyle, {right: newBgRight, left: null}),
+            fgStyle: Object.assign({}, arrowStyle.fgStyle, {right: newBgRight + 1, left: null})
           })
         }
         style.left = this.margin


### PR DESCRIPTION
Two arrow positioning fixes on small screen:
- when position = bottom / top & arrow right
![image](https://user-images.githubusercontent.com/4126690/32660173-1bd77476-c622-11e7-9f2f-6317574c3e67.png)

- when position = bottom / top & arrow = center the position is not really center:
![image](https://user-images.githubusercontent.com/4126690/32660327-af4ec696-c622-11e7-9463-c6b46f02253d.png)



