### PR TITLE
fix: clean dom when tooltip unmounts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -381,6 +381,7 @@ export default class ToolTip extends Component {
     if (portalNodes[this.props.group]) {
       ReactDOM.unmountComponentAtNode(portalNodes[this.props.group].node)
       clearTimeout(portalNodes[this.props.group].timeout)
+      document.body.removeChild(portalNodes[this.props.group].node);
     }
   }
   createPortal() {


### PR DESCRIPTION
This removes leftover dom nodes when the component unmounts

we are displaying paginated search results where hovering a search result shows some additional details. We are finding that users who paginate a lot will fill up the dom with a lot of empty `<div class="ToolTipPortal"></div>` as they move to the next page

if you want I could also flag this behind a prop `cleanDOMOnUnmount` with a default of false