### PR TITLE
Fixes intermitent bug 84

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -322,8 +322,10 @@ class Card extends Component {
     this.updateSize()
   }
 
-  componentDidUpdate() {
-    this.updateSize()
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props !== prevProps){
+      this.updateSize()
+    }
   }
 
   updateSize() {


### PR DESCRIPTION
componentDidUpdate fired up updateSize which has a setState that fires up again componentDidUpdate. It is recommended to only change the state if the props have changed to not get into this type of endless loop. This fixes the intermittent issue we are having and closes #84 