### PR TITLE
WIP: Add the possibility to force the Card component to update its size and position.

### DIFF
--- a/example/src/advanced.js
+++ b/example/src/advanced.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react'
+
+import ToolTip from './../../'
+
+export default class Advanced extends Component {
+  tooltipRef = React.createRef()
+  state = {
+    tooltipOpened: false,
+  }
+
+  escape(html) {
+    return document.createElement('div').appendChild(document.createTextNode(html)).parentNode.innerHTML
+  }
+
+  getBasicExample() {
+    return {
+      __html: this.escape(`
+      tooltipRef = React.createRef()
+      state = {
+        tooltipOpened: false,
+      }
+      
+      [...]
+
+      handleClick = () => {
+        this.setState(state => ({ tooltipOpened: !state.tooltipOpened }))
+      }
+    
+      handleScroll = () => {
+        if (this.tooltipRef.current) {
+          this.tooltipRef.current.updateToolTipSize()
+        }
+      }
+
+      [...]
+
+      render() {
+        <div onScroll={this.handleScroll} style={{
+          backgroundColor: "#eee",
+          height: '200px',
+          overflowY: 'scroll',
+        }}>
+          <div className="btn btn-default"
+            id="tooltip-trigger"
+            onClick={this.handleClick}
+            style={{ margin: '100px' }}>
+            {this.state.tooltipOpened ? "Close" : "Open"} ToolTip.
+          </div>
+          <ToolTip
+            active={this.state.tooltipOpened}
+            ref={this.tooltipRef}
+            parent="#tooltip-trigger"
+            position="bottom"
+            arrow="left">
+            This ToolTip should update its position when scrolling.
+          </ToolTip>
+        </div>
+      }
+`)
+    }
+  }
+
+  handleClick = () => {
+    this.setState(state => ({ tooltipOpened: !state.tooltipOpened }))
+  }
+
+  handleScroll = () => {
+    if (this.tooltipRef.current) {
+      this.tooltipRef.current.updateToolTipSize()
+    }
+  }
+
+  render() {
+    return (
+      <div className="row" style={{ marginTop: 20 }}>
+        <div className="col-lg-12">
+          <div style={{ marginBottom: 20 }}>
+            This example illustrate a common problem: If the ToolTip is open while the user scroll, the Tooltip will not update its position,
+            effectively not looking 'attached' to its parent anymore.
+            <br />
+            To fix this, we use the <code>updateToolTipSize</code> function exposed by the <code>ToolTip</code> component via a React ref.
+            <pre dangerouslySetInnerHTML={this.getBasicExample()} />
+          </div>
+          <div style={{ marginBottom: 20 }}>
+            <div onScroll={this.handleScroll} style={{
+              backgroundColor: "#eee",
+              height: '200px',
+              overflowY: 'scroll',
+            }}>
+              <div className="btn btn-default"
+                id="tooltip-trigger"
+                onClick={this.handleClick}
+                style={{ margin: '100px' }}>
+                {this.state.tooltipOpened ? "Close" : "Open"} ToolTip.
+              </div>
+              <ToolTip
+                active={this.state.tooltipOpened}
+                ref={this.tooltipRef}
+                parent="#tooltip-trigger"
+                position="bottom"
+                arrow="left">
+                This ToolTip should update its position when scrolling.
+            </ToolTip>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -6,10 +6,11 @@ import Home from './home'
 import Stateful from './stateful'
 import Groups from './groups'
 import Style from './style'
+import Advanced from './advanced'
 
 export default class App extends React.Component {
     state = {
-        users: {list: []},
+        users: { list: [] },
     }
 
     componentWillMount() {
@@ -17,7 +18,7 @@ export default class App extends React.Component {
             .send()
             .set('Accept', 'application/json')
             .end((err, res) => {
-                this.setState({users: res.body})
+                this.setState({ users: res.body })
             })
     }
 
@@ -26,21 +27,23 @@ export default class App extends React.Component {
 
         return (
             <Router>
-              <div className="row">
-                  <div className="col-lg-12">
-                      <ul className="nav nav-tabs">
-                        <li><Link to="/">Basic usage</Link></li>
-                        <li><Link to="/stateful">Stateful usage</Link></li>
-                        <li><Link to="/groups">Groups</Link></li>
-                        <li><Link to="/style">Style</Link></li>
-                      </ul>
-                  </div>
-              </div>
+                <div className="row">
+                    <div className="col-lg-12">
+                        <ul className="nav nav-tabs">
+                            <li><Link to="/">Basic usage</Link></li>
+                            <li><Link to="/stateful">Stateful usage</Link></li>
+                            <li><Link to="/groups">Groups</Link></li>
+                            <li><Link to="/style">Style</Link></li>
+                            <li><Link to="/advanced">advanced</Link></li>
+                        </ul>
+                    </div>
+                </div>
 
-              <Route path="/" exact render={ () => <Home users={ users } /> } />
-              <Route path="/stateful" render={ () => <Stateful users={ users } /> } />
-              <Route path="/groups" render={ () => <Groups users={ users } /> } />
-              <Route path="/style" render={ () => <Style users={ users } /> } />
+                <Route path="/" exact render={() => <Home users={users} />} />
+                <Route path="/stateful" render={() => <Stateful users={users} />} />
+                <Route path="/groups" render={() => <Groups users={users} />} />
+                <Route path="/style" render={() => <Style users={users} />} />
+                <Route path="/advanced" render={() => <Advanced users={users} />} />
             </Router>
         )
     }

--- a/src/Card.js
+++ b/src/Card.js
@@ -36,29 +36,34 @@ export default class Card extends Component {
     position: 'right',
     arrow: null,
     align: null,
-    style: {style: {}, arrowStyle: {}},
+    style: { style: {}, arrowStyle: {} },
     useHover: true
   }
 
-  state = {
-    hover: false,
-    transition: 'opacity',
-    width: 0,
-    height: 0,
+  constructor(props) {
+    super(props)
+    this.state = {
+      hover: false,
+      transition: 'opacity',
+      width: 0,
+      height: 0,
+      top: undefined,
+      left: undefined,
+    }
+
+    this.margin = 15
+
+    this.defaultArrowStyle = {
+      color: '#fff',
+      borderColor: 'rgba(0,0,0,.4)'
+    }
+
+    this.rootRef = React.createRef()
   }
-
-  margin = 15
-
-  defaultArrowStyle = {
-    color: '#fff',
-    borderColor: 'rgba(0,0,0,.4)'
-  }
-
-  rootRef = React.createRef()
 
   getGlobalStyle() {
     if (!this.props.parentEl) {
-      return {display: 'none'}
+      return { display: 'none' }
     }
 
     const style = {
@@ -99,7 +104,7 @@ export default class Card extends Component {
     let bgColorBorder = `11px solid ${bgBorderColor}`
     let bgTransBorder = `${BG_SIZE}px solid transparent`
 
-    let {position, arrow} = this.props
+    let { position, arrow } = this.props
 
     if (position === 'left' || position === 'right') {
       fgStyle.top = '50%'
@@ -171,7 +176,7 @@ export default class Card extends Component {
       }
     }
 
-    let {color, borderColor, ...propsArrowStyle} = this.props.style.arrowStyle
+    let { color, borderColor, ...propsArrowStyle } = this.props.style.arrowStyle
 
     return {
       fgStyle: this.mergeStyle(fgStyle, propsArrowStyle),
@@ -192,15 +197,28 @@ export default class Card extends Component {
     return style
   }
 
+  getTop() {
+    let parent = this.props.parentEl
+    if (!parent) return undefined
+    let tooltipPosition = parent.getBoundingClientRect()
+    let scrollY = (window.scrollY !== undefined) ? window.scrollY : window.pageYOffset
+    return scrollY + tooltipPosition.top
+  }
+
+  getLeft() {
+    let parent = this.props.parentEl
+    if (!parent) return undefined
+    let tooltipPosition = parent.getBoundingClientRect()
+    let scrollX = (window.scrollX !== undefined) ? window.scrollX : window.pageXOffset
+    return scrollX + tooltipPosition.left
+  }
+
   getStyle(position, arrow) {
     let alignOffset = 0
     let parent = this.props.parentEl
     let align = this.props.align
-    let tooltipPosition = parent.getBoundingClientRect()
-    let scrollY = (window.scrollY !== undefined) ? window.scrollY : window.pageYOffset
-    let scrollX = (window.scrollX !== undefined) ? window.scrollX : window.pageXOffset
-    let top = scrollY + tooltipPosition.top
-    let left = scrollX + tooltipPosition.left
+    let top = this.state.top !== undefined ? this.state.top : this.getTop()
+    let left = this.state.left !== undefined ? this.state.left : this.getLeft()
     let style = {}
 
     const parentSize = {
@@ -300,15 +318,15 @@ export default class Card extends Component {
       }
     }
 
-    return {style, arrowStyle}
+    return { style, arrowStyle }
   }
 
   handleMouseEnter = () => {
-    this.props.active && this.props.useHover && this.setState({hover: true})
+    this.props.active && this.props.useHover && this.setState({ hover: true })
   }
 
   handleMouseLeave = () => {
-    this.setState({hover: false})
+    this.setState({ hover: false })
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -322,7 +340,7 @@ export default class Card extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.props !== prevProps){
+    if (this.props !== prevProps) {
       this.updateSize()
     }
   }
@@ -330,24 +348,31 @@ export default class Card extends Component {
   updateSize() {
     const newWidth = this.rootRef.current.offsetWidth
     const newHeight = this.rootRef.current.offsetHeight
+    const newTop = this.getTop()
+    const newtLeft = this.getLeft()
 
-    if (newWidth !== this.state.width || newHeight !== this.state.height) {
+    if (newWidth !== this.state.width
+      || newHeight !== this.state.height
+      || newTop !== this.state.top
+      || newtLeft !== this.state.left) {
       this.setState({
         width: newWidth,
         height: newHeight,
+        top: newTop,
+        left: newtLeft
       })
     }
   }
 
   render() {
-    let {style, arrowStyle} = this.checkWindowPosition(this.getGlobalStyle(), this.getArrowStyle())
+    let { style, arrowStyle } = this.checkWindowPosition(this.getGlobalStyle(), this.getArrowStyle())
 
     return (
-      <div style={style} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} ref={ this.rootRef }>
+      <div style={style} onMouseEnter={this.handleMouseEnter} onMouseLeave={this.handleMouseLeave} ref={this.rootRef}>
         {this.props.arrow ? (
           <div>
-            <span style={arrowStyle.fgStyle}/>
-            <span style={arrowStyle.bgStyle}/>
+            <span style={arrowStyle.fgStyle} />
+            <span style={arrowStyle.bgStyle} />
           </div>)
           : null
         }
@@ -358,7 +383,7 @@ export default class Card extends Component {
 }
 
 const executeFunctionIfExist = (object, key) => {
-  if (Object.prototype.hasOwnProperty.call(object, key)){
+  if (Object.prototype.hasOwnProperty.call(object, key)) {
     object[key]()
   }
 }


### PR DESCRIPTION
⚠️ This PR include an important refactor of the `ToolTip` component and is very much a WIP ⚠️ 


# Introduction 

This PR stem from a problem that we encountered in a project that use `react-portal-toolip`:
We have a component that open a `ToolTip` on a click of a button. Clicking again on the button close it.
It means, the user is able to scroll, even when the tooltip is visible. We found that the position of the tooltip was not updating when scrolling, leading to the tooltip be out of place in regard to its parent.


# Current work-around

A way to work around that was to use a junk props that the `ToolTip` nor the `Card` component use or interact with. Then, to force the component to update its position, we can change the value of this props to force a re-render of the component, which will also recalculate its position.

This method was not satisfying in the long term, whether it be for quality of code reason or performance reason.


# Proposed approach

Using the `ref` system of React, we can call a method from a component class (see [this question](https://stackoverflow.com/questions/37949981/call-child-method-from-parent)). Using this, we can create a function in the `Card` component which will trigger a recalculation of its position.
We then expose this function in the parent `ToolTip` component.
This allow any component that maintain a `ref` of the `ToolTip`  to be able to force a recalculation of the `Card` size & position by calling the exposed function.


# Consequences on the code base

The current approach to react the `ToolTip` portal using `ReactDOM.render` was making such a proposal impossible, as `ReactDOM.render` cannot insure that the `ref` will be properly setup (see [this answer](https://stackoverflow.com/a/50019873/1149206)). For this reason, we had to refactor the code of the `ToolTip` component to use `ReactDOM.createPortal` instead.

The current `Card` component had no separation between the style and the position computation, which was required for this proposal. To solve this, we added to the state a `top` and `left` value that reflect the position value that will be passed to the component.


# What is done

- Refactoring the `ToolTip` component to use `ReactDOM.createPortal`
- Creating a function in `Card` that will allow to force the re-calculation of the card position.
- Exposing this function from the `ToolTip` component
- Added an "Advanced" tab in the example website with a "Update position on scroll" example

# What remains to be done

- Re-adding the group system which was removed in the `React.createPortal` refactoring
- A few code cleanup
- Documentation


