### PR TITLE
Replacing deprecated React lifecycle methods

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -12,7 +12,7 @@ export default class App extends React.Component {
         users: {list: []},
     }
 
-    componentWillMount() {
+    componentDidMount() {
         request('GET', 'https://api.dailymotion.com/users?fields=id,username,screenname,cover_250_url,avatar_120_url,videos_total,fans_total&list=recommended&limit=20')
             .send()
             .set('Accept', 'application/json')

--- a/src/ToolTip.js
+++ b/src/ToolTip.js
@@ -23,54 +23,51 @@ export default class ToolTip extends React.Component {
     tooltipTimeout: 500
   }
 
-  createPortal() {
-    portalNodes[this.props.group] = {
+  state = {
+    wasActive: false
+  }
+
+  static createPortal(props) {
+    portalNodes[props.group] = {
       node: document.createElement('div'),
       timeout: false
     }
-    portalNodes[this.props.group].node.className = 'ToolTipPortal'
-    document.body.appendChild(portalNodes[this.props.group].node)
+    portalNodes[props.group].node.className = 'ToolTipPortal'
+    document.body.appendChild(portalNodes[props.group].node)
   }
 
-  renderPortal(props) {
-    if (!portalNodes[this.props.group]) {
-      this.createPortal()
+  static renderPortal(props) {
+    if (!portalNodes[props.group]) {
+      this.createPortal(props)
     }
     let {parent, ...other} = props
     let parentEl = typeof parent === 'string' ? document.querySelector(parent) : parent
-    ReactDOM.render(<Card parentEl={parentEl} {...other}/>, portalNodes[this.props.group].node)
+    ReactDOM.render(<Card parentEl={parentEl} {...other}/>, portalNodes[props.group].node)
   }
 
-  componentDidMount() {
-    if (!this.props.active) {
-      return
+  static getDerivedStateFromProps(props, state) {
+    const portalNode = portalNodes[props.group]
+    if (!state.wasActive && !props.active) {
+      return null
     }
 
-    this.renderPortal(this.props)
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if ((!portalNodes[this.props.group] && !nextProps.active) ||
-      (!this.props.active && !nextProps.active)) {
-      return
+    if (portalNode && portalNode.timeout) {
+      clearTimeout(portalNode.timeout)
     }
 
-    let props = { ...nextProps }
-    let newProps = { ...nextProps }
-
-    if (portalNodes[this.props.group] && portalNodes[this.props.group].timeout) {
-      clearTimeout(portalNodes[this.props.group].timeout)
-    }
-
-    if (this.props.active && !props.active) {
+    const newProps = {...props}
+    if (state.wasActive && !props.active) {
       newProps.active = true
-      portalNodes[this.props.group].timeout = setTimeout(() => {
-        props.active = false
-        this.renderPortal(props)
-      }, this.props.tooltipTimeout)
+      portalNode.timeout = setTimeout(() => {
+        ToolTip.renderPortal({...props, active: false})
+      }, props.tooltipTimeout)
     }
 
-    this.renderPortal(newProps)
+    ToolTip.renderPortal(newProps)
+
+    return {
+      wasActive: props.active
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
React 16.9 is throwing warnings in the console because of usage of `componentWillReceiveProps` in `Tooltip.js`.

This PR uses `getDerivedStateFromProps` instead of both `componentWillReceiveProps` and `componentDidMount`.
